### PR TITLE
4 target networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ wandb
 *.pyc
 .vscode
 __pycache__
+*.tfevents.*

--- a/BaseAgent.py
+++ b/BaseAgent.py
@@ -161,6 +161,7 @@ class BaseAgent:
         """
         Train the agent for total_timesteps
         """
+        self.total_timesteps = total_timesteps
         # Start a timer to log fps:
         self.initial_time = time.thread_time_ns()
 
@@ -200,7 +201,7 @@ class BaseAgent:
                     logger.log_history("rollout/ep_reward", self.rollout_reward, self.env_steps)
                     logger.log_history("rollout/avg_episode_length", avg_ep_len, self.env_steps)
 
-    def _on_step(self):
+    def _on_step(self) -> None:
         """
         This method is called after every step in the environment
         """

--- a/BaseAgent.py
+++ b/BaseAgent.py
@@ -197,9 +197,8 @@ class BaseAgent:
                     self._log_stats()
 
             if done:
-                for logger in self.loggers:
-                    logger.log_history("rollout/ep_reward", self.rollout_reward, self.env_steps)
-                    logger.log_history("rollout/avg_episode_length", avg_ep_len, self.env_steps)
+                self.log_history("rollout/ep_reward", self.rollout_reward, self.env_steps)
+                self.log_history("rollout/avg_episode_length", avg_ep_len, self.env_steps)
 
     def _on_step(self) -> None:
         """
@@ -225,8 +224,7 @@ class BaseAgent:
         # Get the current learning rate from the optimizer:
         # log_class_vars(self, self.logger, LOG_PARAMS)
         for log_name, class_var in self.LOG_PARAMS.items():
-            for logger in self.loggers:
-                logger.log_history(log_name, self.__dict__[class_var], self.env_steps)
+            self.log_history(log_name, self.__dict__[class_var], self.env_steps)
 
                 # logger.dump(step=self.env_steps)
 
@@ -257,10 +255,9 @@ class BaseAgent:
         self.eval_time = eval_time
         self.eval_fps = eval_fps
         self.avg_eval_rwd = avg_reward
-        for logger in self.loggers:
-            logger.log_history('eval/avg_episode_length', n_steps / n_episodes, self.env_steps)
-            logger.log_history('eval/time', eval_time, self.env_steps)
-            logger.log_history('eval/fps', eval_fps, self.env_steps)
+        self.log_history('eval/avg_episode_length', n_steps / n_episodes, self.env_steps)
+        self.log_history('eval/time', eval_time, self.env_steps)
+        self.log_history('eval/fps', eval_fps, self.env_steps)
         return avg_reward
 
     def save(self, path=None):

--- a/DQN.py
+++ b/DQN.py
@@ -68,8 +68,7 @@ class DQN(BaseAgent):
         self.epsilon = max(self.minimum_epsilon, (self.initial_epsilon - self.env_steps / self.total_timesteps / self.exploration_fraction))
 
         if self.env_steps % self.log_interval == 0:
-            for logger in self.loggers:
-                logger.log_history("train/epsilon", self.epsilon, self.env_steps)
+            self.log_history("train/epsilon", self.epsilon, self.env_steps)
 
         # Periodically update the target network:
         if self.use_target_network and self.env_steps % self.target_update_interval == 0:
@@ -111,10 +110,9 @@ class DQN(BaseAgent):
         # Calculate the q ("critic") loss:
         loss = 0.5*torch.nn.functional.mse_loss(curr_q, expected_curr_q)
         
-        for logger in self.loggers:
-            logger.log_history("train/online_q_mean", curr_q.mean().item(), self.env_steps)
-            # log the loss:
-            logger.log_history("train/loss", loss.item(), self.env_steps)
+        self.log_history("train/online_q_mean", curr_q.mean().item(), self.env_steps)
+        # log the loss:
+        logger.log_history("train/loss", loss.item(), self.env_steps)
 
         return loss
 

--- a/DQN.py
+++ b/DQN.py
@@ -1,0 +1,107 @@
+import gymnasium
+import numpy as np
+import torch
+from Architectures import make_mlp
+from BaseAgent import BaseAgent, get_new_params
+from utils import logger_at_folder
+
+class DQN(BaseAgent):
+    def __init__(self,
+                 *args,
+                 gamma: float = 0.99,
+                 minimum_epsilon: float = 0.05,
+                 exploration_fraction: float = 0.5,
+                 initial_epsilon: float = 1.0,
+                 **kwargs,
+                 ):
+        
+        super().__init__(*args, **kwargs)
+        self.kwargs = get_new_params(self, locals())
+        
+        self.algo_name = 'SQL'
+        self.gamma = gamma
+        self.minimum_epsilon = minimum_epsilon
+        self.exploration_fraction = exploration_fraction
+        self.initial_epsilon = initial_epsilon
+        self.epsilon = initial_epsilon
+       
+        self.nA = self.env.action_space.n
+        self.log_hparams(self.kwargs)
+        
+        self.online_qs = self.architecture
+            
+        self.model = self.online_qs
+
+        # Make (all) qs learnable:
+        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=self.learning_rate)
+
+    def _on_step(self) -> None:
+        super()._on_step()
+        # Update epsilon:
+        self.epsilon = max(self.minimum_epsilon, (self.initial_epsilon - self.env_steps / self.total_timesteps / self.exploration_fraction))
+
+        if self.env_steps % self.log_interval == 0:
+            for logger in self.loggers:
+                logger.log_history("train/epsilon", self.epsilon, self.env_steps)
+
+    def exploration_policy(self, state: np.ndarray) -> int:
+        if np.random.rand() < self.epsilon:
+            return self.env.action_space.sample()
+        else:
+            return self.evaluation_policy(state)
+    
+
+    def evaluation_policy(self, state: np.ndarray) -> int:
+        # Get the greedy action from the q values:
+        qvals = self.online_qs(torch.tensor(state))
+        qvals = qvals.squeeze()
+        return torch.argmax(qvals).item()
+    
+
+    def calculate_loss(self, batch):
+        states, actions, next_states, dones, rewards = batch
+        curr_q = self.online_qs(states).squeeze().gather(1, actions.long())
+        with torch.no_grad():
+            if isinstance(self.env.observation_space, gymnasium.spaces.Discrete):
+                states = states.squeeze()
+                next_states = next_states.squeeze()
+            
+            online_curr_q = self.online_qs(states).gather(1, actions)
+
+            online_curr_q = online_curr_q.squeeze(-1)
+
+            next_qs = self.online_qs(next_states)
+            
+            next_v = torch.max(next_qs, dim=-1).values
+            next_v = next_v.reshape(-1, 1)
+
+            # Backup equation:
+            expected_curr_q = rewards + self.gamma * next_v * (1-dones)
+
+        # Calculate the q ("critic") loss:
+        loss = 0.5*torch.nn.functional.mse_loss(curr_q, expected_curr_q)
+        
+        for logger in self.loggers:
+            logger.log_history("train/online_q_mean", curr_q.mean().item(), self.env_steps)
+            # log the loss:
+            logger.log_history("train/loss", loss.item(), self.env_steps)
+
+        return loss
+
+
+if __name__ == '__main__':
+    import gymnasium as gym
+    env = gym.make('CartPole-v1')
+    from Logger import WandBLogger, TensorboardLogger
+    logger = TensorboardLogger('logs/cartpole')
+    #logger = WandBLogger(entity='jacobhadamczyk', project='test')
+    mlp = make_mlp(env.unwrapped.observation_space.shape[0], env.unwrapped.action_space.n, hidden_dims=[32, 32])#, activation=torch.nn.Mish)
+    agent = DQN(env, 
+                       architecture=mlp, 
+                       loggers=(logger,),
+                       learning_rate=0.001,
+                       train_interval=1,
+                       gradient_steps=1,
+                       batch_size=256,
+                       )
+    agent.learn(total_timesteps=50000)

--- a/SoftQAgent.py
+++ b/SoftQAgent.py
@@ -40,6 +40,10 @@ class SoftQAgent(BaseAgent):
             else:
                 print("WARNING: No polyak tau specified for soft target updates. Using default tau=1 for hard updates.")
                 self.polyak_tau = 1.0
+
+            if target_update_interval is None:
+                print("WARNING: Target network update interval not specified. Using default interval of 1 step.")
+                self.target_update_interval = 1
         # Alias the "target" with online net if target is not used:
         else:
             self.target_softqs = self.online_softqs

--- a/SoftQAgent.py
+++ b/SoftQAgent.py
@@ -103,7 +103,7 @@ class SoftQAgent(BaseAgent):
         if self.use_target_network and self.env_steps % self.target_update_interval == 0:
             # Use Polyak averaging as specified:
             polyak(self.online_softqs, self.target_softqs, self.polyak_tau)
-            # self.target_softqs.load_state_dict(self.online_softqs.state_dict())
+
         super()._on_step()
 
 

--- a/SoftQAgent.py
+++ b/SoftQAgent.py
@@ -95,10 +95,9 @@ class SoftQAgent(BaseAgent):
         # Calculate the softq ("critic") loss:
         loss = 0.5*torch.nn.functional.mse_loss(curr_softq, expected_curr_softq)
         
-        for logger in self.loggers:
-            logger.log_history("train/online_q_mean", curr_softq.mean().item(), self.env_steps)
-            # log the loss:
-            logger.log_history("train/loss", loss.item(), self.env_steps)
+        self.log_history("train/online_q_mean", curr_softq.mean().item(), self.env_steps)
+        # log the loss:
+        self.log_history("train/loss", loss.item(), self.env_steps)
 
         return loss
     

--- a/SoftQAgent.py
+++ b/SoftQAgent.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import gymnasium
 import numpy as np
 import torch
@@ -10,6 +11,8 @@ class SoftQAgent(BaseAgent):
                  *args,
                  gamma: float = 0.99,
                  beta: float = 5.0,
+                 use_target_network: bool = False,
+                 target_update_interval: Optional[int] = None,
                  **kwargs,
                  ):
         
@@ -19,11 +22,24 @@ class SoftQAgent(BaseAgent):
         self.algo_name = 'SQL'
         self.gamma = gamma
         self.beta = beta
+        self.use_target_network = use_target_network
+        self.target_update_interval = target_update_interval
        
         self.nA = self.env.action_space.n
         self.log_hparams(self.kwargs)
         
         self.online_softqs = self.architecture
+        if self.use_target_network:
+            self.target_softqs = self.architecture
+            self.target_softqs.load_state_dict(self.online_softqs.state_dict())
+        
+        # Alias the "target" with online net if target is not used:
+        else:
+            self.target_softqs = self.online_softqs
+            # Raise a warning if update interval is specified:
+            if target_update_interval is not None:
+                print("WARNING: Target network update interval specified but target network is not used.")
+
             
         self.model = self.online_softqs
 
@@ -55,12 +71,8 @@ class SoftQAgent(BaseAgent):
             if isinstance(self.env.observation_space, gymnasium.spaces.Discrete):
                 states = states.squeeze()
                 next_states = next_states.squeeze()
-            
-            online_curr_softq = self.online_softqs(states).gather(1, actions)
 
-            online_curr_softq = online_curr_softq.squeeze(-1)
-
-            next_softqs = self.online_softqs(next_states)
+            next_softqs = self.target_softqs(next_states)
             
             next_v = 1/self.beta * (torch.logsumexp(
                 self.beta * next_softqs, dim=-1) - torch.log(torch.Tensor([self.nA])).to(self.device))
@@ -78,6 +90,12 @@ class SoftQAgent(BaseAgent):
             logger.log_history("train/loss", loss.item(), self.env_steps)
 
         return loss
+    
+    def _on_step(self) -> None:
+        # Periodically update the target network:
+        if self.use_target_network and self.env_steps % self.target_update_interval == 0:
+            self.target_softqs.load_state_dict(self.online_softqs.state_dict())
+        super()._on_step()
 
 
 if __name__ == '__main__':
@@ -95,5 +113,7 @@ if __name__ == '__main__':
                        train_interval=1,
                        gradient_steps=1,
                        batch_size=256,
+                       use_target_network=True,
+                       target_update_interval=10
                        )
     agent.learn(total_timesteps=50000)

--- a/test_hparam_sampler.py
+++ b/test_hparam_sampler.py
@@ -1,0 +1,59 @@
+import unittest
+import random
+import numpy as np
+from unittest.mock import patch
+
+# Assuming the function `sample_wandb_hyperparams` is defined in a module named `hyperparam_sampling`
+# from hyperparam_sampling import sample_wandb_hyperparams
+from utils import sample_wandb_hyperparams
+
+class TestSampleWandbHyperparams(unittest.TestCase):
+
+    @patch('random.choice')
+    @patch('random.uniform')
+    @patch('random.normalvariate')
+    def test_sample_values(self, mock_normalvariate, mock_uniform, mock_choice):
+        mock_choice.side_effect = lambda x: x[0]
+        mock_uniform.side_effect = lambda a, b: (a + b) / 2
+        mock_normalvariate.side_effect = lambda mean, std: mean
+
+        params = {
+            'param1': {'values': [1, 2, 3]},
+            'param2': {'distribution': 'uniform', 'min': 0, 'max': 10},
+            'param3': {'distribution': 'q_uniform', 'min': 1, 'max': 5},
+            'param4': {'distribution': 'normal', 'mean': 0, 'std': 1},
+            'param5': {'distribution': 'log_uniform_values', 'min': 1, 'max': 10},
+            'param6': {'distribution': 'q_log_uniform_values', 'min': 1, 'max': 10}
+        }
+
+        expected = {
+            'param1': 1,
+            'param2': 5.0,
+            'param3': 3,
+            'param4': 0,
+            'param5': np.exp((np.log(10) + np.log(1)) / 2),
+            'param6': int(np.exp((np.log(10) + np.log(1)) / 2))
+        }
+
+        result = sample_wandb_hyperparams(params)
+        self.assertEqual(result, expected)
+        # Check the q distribution params are int:
+        self.assertIsInstance(result['param3'], int)
+        self.assertIsInstance(result['param6'], int)
+
+    def test_not_implemented_distribution(self):
+        params = {
+            'param1': {'distribution': 'unknown', 'min': 0, 'max': 10}
+        }
+        with self.assertRaises(NotImplementedError):
+            sample_wandb_hyperparams(params)
+
+    def test_not_implemented_format(self):
+        params = {
+            'param1': {'min': 0, 'max': 10}
+        }
+        with self.assertRaises(NotImplementedError):
+            sample_wandb_hyperparams(params)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_target_networks.py
+++ b/tests/test_target_networks.py
@@ -1,0 +1,1 @@
+# TODO: Use tests from the u-chi-learning repo


### PR DESCRIPTION
(Also merged w/ DQN)

I've added target networks to SQL and DQN. There is a lot of repeated code because of this, but to reduce additional abstraction (Which wouldn't be needed for policy-based methods), I think it's okay to keep it in the individual agent classes. 
Basic logic:
- Use of target is a boolean flag
- if target used, user is warned if no target update interval or polyak are specified. (if this is the case, they are set to default values of 1.0: update every step and do hard update)
- Else we check for sensible values (polyak \in [0,1])
- We give an alias to self.target_q, so that if targets are not used, the calculation in calculate_loss doesn't have to change: it is always based on self.target_q(next_state).

I re-ran cartpole experiments and things still look okay, more stable q values. However, it seems like DQN with targets is running slower than I expected (compared to DQN w/o target). Maybe we can double check with profiling. I also found some old extraneous code, so removed it